### PR TITLE
Allow users to disable Installation of RSAT or change method of installation to accommodate Windows Clients

### DIFF
--- a/ludus_child_domain_join/defaults/main.yml
+++ b/ludus_child_domain_join/defaults/main.yml
@@ -4,4 +4,8 @@ dns_domain_name: "dev.test.local"
 dc_ip: "10.2.30.10" 
 domain_admin_user: "domainadmin@dev.test.local"
 domain_admin_password: "password"
-#domain_ou_path: "OU=Windows,OU=Servers,DC=dev,DC=test,DC=local" # Commenting out for now 
+#domain_ou_path: "OU=Windows,OU=Servers,DC=dev,DC=test,DC=local" # Commenting out for now
+
+# RSAT Installation Control
+install_rsat_tools: false  # Default to false since RSAT isn't required for domain join and can cause issues
+rsat_install_method: "dism"  # Use DISM method for Windows 10/11 clients (ignored if install_rsat_tools is false)

--- a/ludus_child_domain_join/defaults/main.yml
+++ b/ludus_child_domain_join/defaults/main.yml
@@ -8,4 +8,4 @@ domain_admin_password: "password"
 
 # RSAT Installation Control
 install_rsat_tools: false  # Default to false since RSAT isn't required for domain join and can cause issues
-rsat_install_method: "dism"  # Use DISM method for Windows 10/11 clients (ignored if install_rsat_tools is false)
+rsat_install_method: "auto"  # Use DISM method for Windows 10/11 clients (ignored if install_rsat_tools is false)

--- a/ludus_child_domain_join/tasks/main.yml
+++ b/ludus_child_domain_join/tasks/main.yml
@@ -35,10 +35,10 @@
     - rsat_install_method | default('auto') in ['feature', 'auto']
   ignore_errors: yes
 
-- name: Install all RSAT Tools via PowerShell (Client)
+- name: Install RSAT Active Directory Tools via PowerShell (Client)
   win_powershell:
     script: |
-      Get-WindowsCapability -Online | Where-Object Name -Like 'RSAT*' | Add-WindowsCapability -Online
+      Get-WindowsCapability -Online | Where-Object Name -Like 'Rsat.ActiveDirectory.DS-LDS.Tools*' | Add-WindowsCapability -Online
   when: 
     - install_rsat_tools | default(false)
     - rsat_install_method | default('auto') in ['powershell', 'auto']

--- a/ludus_child_domain_join/tasks/main.yml
+++ b/ludus_child_domain_join/tasks/main.yml
@@ -15,28 +15,30 @@
         state: domain
         reboot: true 
       register: domain_join_result
-      until: domain_join_result is succeeded
+      until: domain_join_result is succeeded or domain_join_result.retries == 10
       retries: 10
       delay: 60
       ignore_errors: yes
-
   rescue:
     - name: Domain join failed after retries
       ansible.builtin.fail:
         msg: "Domain join failed after multiple retries"
       when: domain_join_result is defined and domain_join_result.failed
 
-- name: Install RSAT AD Tools
+- name: Install RSAT AD Tools via Windows Feature (Server)
   win_feature:
     name: "RSAT-ADDS"
     state: present
     include_management_tools: true
+  when: 
+    - install_rsat_tools | default(true)
+    - rsat_install_method | default('auto') in ['feature', 'auto']
+  ignore_errors: yes
 
-- name: Ensure the server is rebooted if required
-  win_reboot:
-
-- name: Configure DNS to the child domain controller's ip address 2
-  win_dns_client:
-    adapter_names: "*"
-    ipv4_addresses:
-      - "{{ dc_ip }}"
+- name: Install RSAT AD Tools via DISM (Client)
+  win_shell: |
+    DISM /Online /Add-Capability /CapabilityName:Rsat.ActiveDirectory.DS-LDS.Tools~~~~0.0.1.0
+  when: 
+    - install_rsat_tools | default(true)
+    - rsat_install_method | default('auto') in ['dism', 'auto']
+  ignore_errors: yes

--- a/ludus_child_domain_join/tasks/main.yml
+++ b/ludus_child_domain_join/tasks/main.yml
@@ -31,14 +31,15 @@
     state: present
     include_management_tools: true
   when: 
-    - install_rsat_tools | default(true)
+    - install_rsat_tools | default(false)
     - rsat_install_method | default('auto') in ['feature', 'auto']
   ignore_errors: yes
 
-- name: Install RSAT AD Tools via DISM (Client)
-  win_shell: |
-    DISM /Online /Add-Capability /CapabilityName:Rsat.ActiveDirectory.DS-LDS.Tools~~~~0.0.1.0
+- name: Install all RSAT Tools via PowerShell (Client)
+  win_powershell:
+    script: |
+      Get-WindowsCapability -Online | Where-Object Name -Like 'RSAT*' | Add-WindowsCapability -Online
   when: 
-    - install_rsat_tools | default(true)
-    - rsat_install_method | default('auto') in ['dism', 'auto']
+    - install_rsat_tools | default(false)
+    - rsat_install_method | default('auto') in ['powershell', 'auto']
   ignore_errors: yes


### PR DESCRIPTION
Currently RSAT is auto installed on ludus_child_domain_join roles. The method of installation fails when attempting to join a workstation. This allows user's to skip installation of RSAT or use powershell to install it. 